### PR TITLE
ZOZOアプリのお気に入り画面でよく使う色を定義した

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,8 @@ repository for training UI of Android apps
 | 女性の画像       |  person_image_pink       |
 | 中性の画像    |  person_image_yellow     |
 | グレーのテキスト色     |  text_gray     |
+
+## 参考画像(お気に入り画面)
+| Before | After |
+ | -------- | ------ |
+| <image src="" width="320">|<image src="https://user-images.githubusercontent.com/77588574/136655394-ac30a752-ce3e-4813-bbc7-9cecdded94b6.png"  width="320"> |

--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
 # AndroidUITrain
 repository for training UI of Android apps
+
+##定義されたcolor resourceの意味
+| 使われている部分 | color resource 名 |
+|:-----------|------------:|
+| ブランド追加ボタンの黒       | zozo_black (微妙に真っ黒ではなかった)        |
+| 画面上部の濃いめのグレー     | dark_gray     |
+| 画面上部の薄めのグレー        | light_gray        |
+| 男性の画像          | person_image_blue          |
+| 女性の画像       |  person_image_pink       |
+| 中性の画像    |  person_image_yellow     |
+| グレーのテキスト色     |  text_gray     |

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # AndroidUITrain
 repository for training UI of Android apps
 
-##定義されたcolor resourceの意味
+## 定義されたcolor resourceの意味
 | 使われている部分 | color resource 名 |
 |:-----------|------------:|
 | ブランド追加ボタンの黒       | zozo_black (微妙に真っ黒ではなかった)        |

--- a/app/src/main/java/com/nemo/androiduitraining/view/fragment/favorite/FavoriteFragment.kt
+++ b/app/src/main/java/com/nemo/androiduitraining/view/fragment/favorite/FavoriteFragment.kt
@@ -1,4 +1,4 @@
-package com.nemo.androiduitraining.view.fragment
+package com.nemo.androiduitraining.view.fragment.favorite
 
 import androidx.fragment.app.Fragment
 

--- a/app/src/main/java/com/nemo/androiduitraining/view/fragment/home/HomeFragment.kt
+++ b/app/src/main/java/com/nemo/androiduitraining/view/fragment/home/HomeFragment.kt
@@ -1,4 +1,4 @@
-package com.nemo.androiduitraining.view.fragment
+package com.nemo.androiduitraining.view.fragment.home
 
 import androidx.fragment.app.Fragment
 

--- a/app/src/main/java/com/nemo/androiduitraining/view/fragment/other/OtherFragment.kt
+++ b/app/src/main/java/com/nemo/androiduitraining/view/fragment/other/OtherFragment.kt
@@ -1,4 +1,4 @@
-package com.nemo.androiduitraining.view.fragment
+package com.nemo.androiduitraining.view.fragment.other
 
 import androidx.fragment.app.Fragment
 

--- a/app/src/main/java/com/nemo/androiduitraining/view/fragment/ranking/RankingFragment.kt
+++ b/app/src/main/java/com/nemo/androiduitraining/view/fragment/ranking/RankingFragment.kt
@@ -1,4 +1,4 @@
-package com.nemo.androiduitraining.view.fragment
+package com.nemo.androiduitraining.view.fragment.ranking
 
 import androidx.fragment.app.Fragment
 

--- a/app/src/main/java/com/nemo/androiduitraining/view/fragment/search/SearchFragment.kt
+++ b/app/src/main/java/com/nemo/androiduitraining/view/fragment/search/SearchFragment.kt
@@ -1,4 +1,4 @@
-package com.nemo.androiduitraining.view.fragment
+package com.nemo.androiduitraining.view.fragment.search
 
 import androidx.fragment.app.Fragment
 

--- a/app/src/main/res/navigation/main_navigation.xml
+++ b/app/src/main/res/navigation/main_navigation.xml
@@ -6,27 +6,27 @@
 
     <custom_fragment
         android:id="@+id/homeFragment"
-        android:name="com.nemo.androiduitraining.view.fragment.HomeFragment"
+        android:name="com.nemo.androiduitraining.view.fragment.home.HomeFragment"
         android:label="MainHomeFragment"
         android:tag="home"/>
     <custom_fragment
         android:id="@+id/favoriteFragment"
-        android:name="com.nemo.androiduitraining.view.fragment.FavoriteFragment"
+        android:name="com.nemo.androiduitraining.view.fragment.favorite.FavoriteFragment"
         android:label="MainFavoriteFragment"
         android:tag="favorite"/>
     <custom_fragment
         android:id="@+id/searchFragment"
-        android:name="com.nemo.androiduitraining.view.fragment.SearchFragment"
+        android:name="com.nemo.androiduitraining.view.fragment.search.SearchFragment"
         android:label="MainSearchFragment"
         android:tag="search"/>
     <custom_fragment
         android:id="@+id/rankingFragment"
-        android:name="com.nemo.androiduitraining.view.fragment.RankingFragment"
+        android:name="com.nemo.androiduitraining.view.fragment.ranking.RankingFragment"
         android:label="MainRankingFragment"
         android:tag="ranking"/>
     <custom_fragment
         android:id="@+id/otherFragment"
-        android:name="com.nemo.androiduitraining.view.fragment.OtherFragment"
+        android:name="com.nemo.androiduitraining.view.fragment.other.OtherFragment"
         android:label="MainOtherFragment"
         android:tag="other"/>
 </navigation>

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -1,13 +1,13 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <!-- Base application theme. -->
-    <style name="Theme.AndroidUITraining" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
+    <style name="Theme.AndroidUITraining" parent="Theme.MaterialComponents.Light.NoActionBar">
         <!-- Primary brand color. -->
-        <item name="colorPrimary">@color/purple_200</item>
-        <item name="colorPrimaryVariant">@color/purple_700</item>
-        <item name="colorOnPrimary">@color/black</item>
+        <item name="colorPrimary">@color/black</item>
+        <item name="colorPrimaryVariant">@color/black</item>
+        <item name="colorOnPrimary">@color/white</item>
         <!-- Secondary brand color. -->
-        <item name="colorSecondary">@color/teal_200</item>
-        <item name="colorSecondaryVariant">@color/teal_200</item>
+        <item name="colorSecondary">@color/black</item>
+        <item name="colorSecondaryVariant">@color/black</item>
         <item name="colorOnSecondary">@color/black</item>
         <!-- Status bar color. -->
         <item name="android:statusBarColor" tools:targetApi="l">?attr/colorPrimaryVariant</item>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,10 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="purple_200">#FFBB86FC</color>
-    <color name="purple_500">#FF6200EE</color>
-    <color name="purple_700">#FF3700B3</color>
-    <color name="teal_200">#FF03DAC5</color>
-    <color name="teal_700">#FF018786</color>
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
 

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -7,4 +7,14 @@
     <color name="teal_700">#FF018786</color>
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
+
+    <color name="dark_gray">#efefef</color>
+    <color name="light_gray">#f8f8f8</color>
+    <color name="pink">#ff7680</color>
+    <color name="light_blue">#23abdd</color>
+    <color name="zozo_black">#2d2d2d</color>
+    <color name="text_gray">#c2c2c2</color>
+    <color name="person_image_blue">#0064d7</color>
+    <color name="person_image_pink">#f16868</color>
+    <color name="person_image_yellow">#f5c955</color>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -6,8 +6,8 @@
         <item name="colorPrimaryVariant">@color/black</item>
         <item name="colorOnPrimary">@color/white</item>
         <!-- Secondary brand color. -->
-        <item name="colorSecondary">@color/teal_200</item>
-        <item name="colorSecondaryVariant">@color/teal_700</item>
+        <item name="colorSecondary">@color/black</item>
+        <item name="colorSecondaryVariant">@color/black</item>
         <item name="colorOnSecondary">@color/black</item>
         <!-- Status bar color. -->
         <item name="android:statusBarColor" tools:targetApi="l">?attr/colorPrimaryVariant</item>


### PR DESCRIPTION
## 概要
ZOZOのアプリのお気に入り画面でよく使う色をcolor resourceに定義した
## 関連情報
| 使われている部分 | color resource 名 |
|:-----------|------------:|
| ブランド追加ボタンの黒       | zozo_black (微妙に真っ黒ではなかった)        |
| 画面上部の濃いめのグレー     | dark_gray     |
| 画面上部の薄めのグレー        | light_gray        |
| 男性の画像          | person_image_blue          |
| 女性の画像       |  person_image_pink       |
| 中性の画像    |  person_image_yellow     |
| グレーのテキスト色     |  text_gray     |

## スクリーンショット
 | Before | After |
 | -------- | ------ |
 | <image src="" width="320">|<image src="https://user-images.githubusercontent.com/77588574/136655394-ac30a752-ce3e-4813-bbc7-9cecdded94b6.png"  width="320"> |
## 懸念点
割と大雑把です

