### PR TITLE
お気に入り画面の新着タブのRecyclerViewとCoordinatorLayout実装

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -64,4 +64,7 @@ dependencies {
     val groupieVersion = "2.9.0"
     implementation ("com.github.lisawray.groupie:groupie:$groupieVersion")
     implementation ("com.github.lisawray.groupie:groupie-viewbinding:$groupieVersion")
+
+    //swiperefreshlayout
+    implementation ("androidx.swiperefreshlayout:swiperefreshlayout:1.2.0-alpha01")
 }

--- a/app/src/main/java/com/nemo/androiduitraining/view/fragment/favorite/FavoriteFragment.kt
+++ b/app/src/main/java/com/nemo/androiduitraining/view/fragment/favorite/FavoriteFragment.kt
@@ -7,7 +7,9 @@ import androidx.viewpager2.adapter.FragmentStateAdapter
 import com.google.android.material.tabs.TabLayoutMediator
 import com.nemo.androiduitraining.R
 import com.nemo.androiduitraining.databinding.FragmentFavoriteBinding
+import dagger.hilt.android.AndroidEntryPoint
 
+@AndroidEntryPoint
 class FavoriteFragment : Fragment(R.layout.fragment_favorite) {
     private var _binding: FragmentFavoriteBinding? = null
     private val binding: FragmentFavoriteBinding

--- a/app/src/main/java/com/nemo/androiduitraining/view/fragment/favorite/FavoriteNewItemFragment.kt
+++ b/app/src/main/java/com/nemo/androiduitraining/view/fragment/favorite/FavoriteNewItemFragment.kt
@@ -5,13 +5,19 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
 import com.nemo.androiduitraining.R
 import com.nemo.androiduitraining.databinding.FragmentFavoriteNewItemBinding
+import com.nemo.androiduitraining.viewModel.favorite.FavoriteNewItemViewModel
+import dagger.hilt.android.AndroidEntryPoint
 
+@AndroidEntryPoint
 class FavoriteNewItemFragment : Fragment(R.layout.fragment_favorite_new_item) {
     companion object {
         fun newInstance() = FavoriteNewItemFragment()
     }
+
+    private val viewModel: FavoriteNewItemViewModel by viewModels()
 
     private var _binding: FragmentFavoriteNewItemBinding? = null
     private val binding: FragmentFavoriteNewItemBinding

--- a/app/src/main/java/com/nemo/androiduitraining/view/fragment/favorite/FavoriteNewItemFragment.kt
+++ b/app/src/main/java/com/nemo/androiduitraining/view/fragment/favorite/FavoriteNewItemFragment.kt
@@ -4,14 +4,18 @@ import android.os.Bundle
 import android.view.View
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.viewbinding.ViewBinding
 import com.nemo.androiduitraining.R
 import com.nemo.androiduitraining.databinding.FragmentFavoriteNewItemBinding
 import com.nemo.androiduitraining.view.fragment.favorite.entity.FavoriteItemCell
 import com.nemo.androiduitraining.view.fragment.favorite.entity.FavoriteNoBrandRegistered
 import com.nemo.androiduitraining.view.fragment.favorite.entity.FavoriteNowPopular
+import com.nemo.androiduitraining.viewModel.favorite.FavoriteNewItemViewModel
 import com.xwray.groupie.GroupieAdapter
+import com.xwray.groupie.viewbinding.BindableItem
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -20,12 +24,15 @@ class FavoriteNewItemFragment : Fragment(R.layout.fragment_favorite_new_item) {
         fun newInstance() = FavoriteNewItemFragment()
     }
 
+    private val viewModel: FavoriteNewItemViewModel by viewModels()
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         val binding = FragmentFavoriteNewItemBinding.bind(view)
 
         val adapter = GroupieCustomAdapter()
         setupRecycler(binding, adapter)
+        fetchBrandsItemAndUpdateList(adapter)
     }
 
     private fun setupRecycler(binding: FragmentFavoriteNewItemBinding, adapter: GroupieCustomAdapter) {
@@ -36,8 +43,6 @@ class FavoriteNewItemFragment : Fragment(R.layout.fragment_favorite_new_item) {
             it.addItemDecoration(createRecyclerDiver(layoutManager))
             it.adapter = adapter
         }
-
-        adapter.updateList()
     }
 
     private fun createRecyclerDiver(layoutManager: LinearLayoutManager): DividerItemDecoration {
@@ -49,23 +54,29 @@ class FavoriteNewItemFragment : Fragment(R.layout.fragment_favorite_new_item) {
         }
     }
 
+    private fun fetchBrandsItemAndUpdateList(adapter: GroupieCustomAdapter) {
+        viewModel.brandLD.observe(viewLifecycleOwner) { brands ->
+            adapter.updateList(brands)
+        }
+        viewModel.fetchBrandItems()
+    }
+
     private class GroupieCustomAdapter : GroupieAdapter() {
+        private var itemList: List<BindableItem<out ViewBinding>> = listOf()
+
         private val defaultViewList = mutableListOf(
             FavoriteNoBrandRegistered(),
             FavoriteNowPopular()
         )
 
-        private fun createItemCells() {
-            for (i in 0..29) {
-                defaultViewList.add(
-                    FavoriteItemCell("ほげほげ", "ふがふが")
+        fun updateList(brandsList: List<FavoriteNewItemViewModel.BrandItem>) {
+            this.itemList = defaultViewList + brandsList.map {
+                FavoriteItemCell(
+                    itemName = it.name,
+                    brandName = it.genre
                 )
             }
-        }
-
-        fun updateList() {
-            createItemCells()
-            update(defaultViewList)
+            update(this.itemList)
         }
     }
 }

--- a/app/src/main/java/com/nemo/androiduitraining/view/fragment/favorite/FavoriteNewItemFragment.kt
+++ b/app/src/main/java/com/nemo/androiduitraining/view/fragment/favorite/FavoriteNewItemFragment.kt
@@ -1,11 +1,12 @@
 package com.nemo.androiduitraining.view.fragment.favorite
 
 import android.os.Bundle
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
+import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
+import androidx.recyclerview.widget.DividerItemDecoration
+import androidx.recyclerview.widget.LinearLayoutManager
 import com.nemo.androiduitraining.R
 import com.nemo.androiduitraining.databinding.FragmentFavoriteNewItemBinding
 import com.nemo.androiduitraining.viewModel.favorite.FavoriteNewItemViewModel
@@ -44,6 +45,21 @@ class FavoriteNewItemFragment : Fragment(R.layout.fragment_favorite_new_item) {
     }
 
     private fun setupRecycler() {
-        binding.favoriteNewItemRecycler.adapter = initializeGroupieAdapter()
+        val layoutManager = LinearLayoutManager(requireContext())
+
+        binding.favoriteNewItemRecycler.also {
+            it.layoutManager = layoutManager
+            it.addItemDecoration(createRecyclerDiver(layoutManager))
+            it.adapter = initializeGroupieAdapter()
+        }
+    }
+
+    private fun createRecyclerDiver(layoutManager: LinearLayoutManager): DividerItemDecoration {
+        val dividerDrawable = ContextCompat.getDrawable(requireContext(), R.drawable.fragment_favorite_new_item_divider)
+        return DividerItemDecoration(requireContext(), layoutManager.orientation).apply {
+            if (dividerDrawable != null) {
+                this.setDrawable(dividerDrawable)
+            }
+        }
     }
 }

--- a/app/src/main/java/com/nemo/androiduitraining/view/fragment/favorite/FavoriteNewItemFragment.kt
+++ b/app/src/main/java/com/nemo/androiduitraining/view/fragment/favorite/FavoriteNewItemFragment.kt
@@ -31,7 +31,7 @@ class FavoriteNewItemFragment : Fragment(R.layout.fragment_favorite_new_item) {
         super.onViewCreated(view, savedInstanceState)
         val binding = FragmentFavoriteNewItemBinding.bind(view)
 
-        val adapter = GroupieCustomAdapter(resources)
+        val adapter = GroupieCustomAdapter()
         setupRecycler(binding, adapter)
         fetchBrandsItemAndUpdateList(adapter)
     }
@@ -62,7 +62,7 @@ class FavoriteNewItemFragment : Fragment(R.layout.fragment_favorite_new_item) {
         viewModel.fetchBrandItems()
     }
 
-    private class GroupieCustomAdapter(private val res: Resources) : GroupieAdapter() {
+    private class GroupieCustomAdapter : GroupieAdapter() {
         private var itemList: List<BindableItem<out ViewBinding>> = listOf()
 
         private val defaultViewList = mutableListOf(
@@ -74,8 +74,7 @@ class FavoriteNewItemFragment : Fragment(R.layout.fragment_favorite_new_item) {
             this.itemList = defaultViewList + brandsList.map {
                 FavoriteItemCell(
                     brandName = it.name,
-                    brandNameJapanese = it.nameJapanese,
-                    res = res
+                    brandNameJapanese = it.nameJapanese
                 )
             }
             update(this.itemList)

--- a/app/src/main/java/com/nemo/androiduitraining/view/fragment/favorite/FavoriteNewItemFragment.kt
+++ b/app/src/main/java/com/nemo/androiduitraining/view/fragment/favorite/FavoriteNewItemFragment.kt
@@ -9,6 +9,7 @@ import androidx.fragment.app.viewModels
 import com.nemo.androiduitraining.R
 import com.nemo.androiduitraining.databinding.FragmentFavoriteNewItemBinding
 import com.nemo.androiduitraining.viewModel.favorite.FavoriteNewItemViewModel
+import com.xwray.groupie.GroupieAdapter
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -26,10 +27,23 @@ class FavoriteNewItemFragment : Fragment(R.layout.fragment_favorite_new_item) {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         _binding = FragmentFavoriteNewItemBinding.bind(view)
+
+        setupRecycler()
     }
 
     override fun onDestroyView() {
         super.onDestroyView()
         _binding = null
+    }
+
+    private fun initializeGroupieAdapter(): GroupieAdapter {
+        viewModel.createItemCells()
+        return GroupieAdapter().apply {
+            this.update(viewModel.defaultViewList)
+        }
+    }
+
+    private fun setupRecycler() {
+        binding.favoriteNewItemRecycler.adapter = initializeGroupieAdapter()
     }
 }

--- a/app/src/main/java/com/nemo/androiduitraining/view/fragment/favorite/FavoriteNewItemFragment.kt
+++ b/app/src/main/java/com/nemo/androiduitraining/view/fragment/favorite/FavoriteNewItemFragment.kt
@@ -20,24 +20,15 @@ class FavoriteNewItemFragment : Fragment(R.layout.fragment_favorite_new_item) {
         fun newInstance() = FavoriteNewItemFragment()
     }
 
-    private var _binding: FragmentFavoriteNewItemBinding? = null
-    private val binding: FragmentFavoriteNewItemBinding
-        get() = _binding!!
-
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        _binding = FragmentFavoriteNewItemBinding.bind(view)
+        val binding = FragmentFavoriteNewItemBinding.bind(view)
 
         val adapter = GroupieCustomAdapter()
-        setupRecycler(adapter)
+        setupRecycler(binding, adapter)
     }
 
-    override fun onDestroyView() {
-        super.onDestroyView()
-        _binding = null
-    }
-
-    private fun setupRecycler(adapter: GroupieCustomAdapter) {
+    private fun setupRecycler(binding: FragmentFavoriteNewItemBinding, adapter: GroupieCustomAdapter) {
         val layoutManager = LinearLayoutManager(requireContext())
 
         binding.favoriteNewItemRecycler.also {

--- a/app/src/main/java/com/nemo/androiduitraining/view/fragment/favorite/FavoriteNewItemFragment.kt
+++ b/app/src/main/java/com/nemo/androiduitraining/view/fragment/favorite/FavoriteNewItemFragment.kt
@@ -1,5 +1,6 @@
 package com.nemo.androiduitraining.view.fragment.favorite
 
+import android.content.res.Resources
 import android.os.Bundle
 import android.view.View
 import androidx.core.content.ContextCompat
@@ -30,7 +31,7 @@ class FavoriteNewItemFragment : Fragment(R.layout.fragment_favorite_new_item) {
         super.onViewCreated(view, savedInstanceState)
         val binding = FragmentFavoriteNewItemBinding.bind(view)
 
-        val adapter = GroupieCustomAdapter()
+        val adapter = GroupieCustomAdapter(resources)
         setupRecycler(binding, adapter)
         fetchBrandsItemAndUpdateList(adapter)
     }
@@ -61,7 +62,7 @@ class FavoriteNewItemFragment : Fragment(R.layout.fragment_favorite_new_item) {
         viewModel.fetchBrandItems()
     }
 
-    private class GroupieCustomAdapter : GroupieAdapter() {
+    private class GroupieCustomAdapter(private val res: Resources) : GroupieAdapter() {
         private var itemList: List<BindableItem<out ViewBinding>> = listOf()
 
         private val defaultViewList = mutableListOf(
@@ -73,7 +74,8 @@ class FavoriteNewItemFragment : Fragment(R.layout.fragment_favorite_new_item) {
             this.itemList = defaultViewList + brandsList.map {
                 FavoriteItemCell(
                     brandName = it.name,
-                    brandNameJapanese = it.nameJapanese
+                    brandNameJapanese = it.nameJapanese,
+                    res = res
                 )
             }
             update(this.itemList)

--- a/app/src/main/java/com/nemo/androiduitraining/view/fragment/favorite/FavoriteNewItemFragment.kt
+++ b/app/src/main/java/com/nemo/androiduitraining/view/fragment/favorite/FavoriteNewItemFragment.kt
@@ -72,8 +72,8 @@ class FavoriteNewItemFragment : Fragment(R.layout.fragment_favorite_new_item) {
         fun updateList(brandsList: List<FavoriteNewItemViewModel.BrandItem>) {
             this.itemList = defaultViewList + brandsList.map {
                 FavoriteItemCell(
-                    itemName = it.name,
-                    brandName = it.genre
+                    brandName = it.name,
+                    brandNameJapanese = it.nameJapanese
                 )
             }
             update(this.itemList)

--- a/app/src/main/java/com/nemo/androiduitraining/view/fragment/favorite/FavoriteNewItemFragment.kt
+++ b/app/src/main/java/com/nemo/androiduitraining/view/fragment/favorite/FavoriteNewItemFragment.kt
@@ -4,12 +4,13 @@ import android.os.Bundle
 import android.view.View
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
-import androidx.fragment.app.viewModels
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.nemo.androiduitraining.R
 import com.nemo.androiduitraining.databinding.FragmentFavoriteNewItemBinding
-import com.nemo.androiduitraining.viewModel.favorite.FavoriteNewItemViewModel
+import com.nemo.androiduitraining.view.fragment.favorite.entity.FavoriteItemCell
+import com.nemo.androiduitraining.view.fragment.favorite.entity.FavoriteNoBrandRegistered
+import com.nemo.androiduitraining.view.fragment.favorite.entity.FavoriteNowPopular
 import com.xwray.groupie.GroupieAdapter
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -19,8 +20,6 @@ class FavoriteNewItemFragment : Fragment(R.layout.fragment_favorite_new_item) {
         fun newInstance() = FavoriteNewItemFragment()
     }
 
-    private val viewModel: FavoriteNewItemViewModel by viewModels()
-
     private var _binding: FragmentFavoriteNewItemBinding? = null
     private val binding: FragmentFavoriteNewItemBinding
         get() = _binding!!
@@ -29,7 +28,8 @@ class FavoriteNewItemFragment : Fragment(R.layout.fragment_favorite_new_item) {
         super.onViewCreated(view, savedInstanceState)
         _binding = FragmentFavoriteNewItemBinding.bind(view)
 
-        setupRecycler()
+        val adapter = GroupieCustomAdapter()
+        setupRecycler(adapter)
     }
 
     override fun onDestroyView() {
@@ -37,21 +37,16 @@ class FavoriteNewItemFragment : Fragment(R.layout.fragment_favorite_new_item) {
         _binding = null
     }
 
-    private fun initializeGroupieAdapter(): GroupieAdapter {
-        viewModel.createItemCells()
-        return GroupieAdapter().apply {
-            this.update(viewModel.defaultViewList)
-        }
-    }
-
-    private fun setupRecycler() {
+    private fun setupRecycler(adapter: GroupieCustomAdapter) {
         val layoutManager = LinearLayoutManager(requireContext())
 
         binding.favoriteNewItemRecycler.also {
             it.layoutManager = layoutManager
             it.addItemDecoration(createRecyclerDiver(layoutManager))
-            it.adapter = initializeGroupieAdapter()
+            it.adapter = adapter
         }
+
+        adapter.updateList()
     }
 
     private fun createRecyclerDiver(layoutManager: LinearLayoutManager): DividerItemDecoration {
@@ -60,6 +55,26 @@ class FavoriteNewItemFragment : Fragment(R.layout.fragment_favorite_new_item) {
             if (dividerDrawable != null) {
                 this.setDrawable(dividerDrawable)
             }
+        }
+    }
+
+    private class GroupieCustomAdapter : GroupieAdapter() {
+        private val defaultViewList = mutableListOf(
+            FavoriteNoBrandRegistered(),
+            FavoriteNowPopular()
+        )
+
+        private fun createItemCells() {
+            for (i in 0..29) {
+                defaultViewList.add(
+                    FavoriteItemCell("ほげほげ", "ふがふが")
+                )
+            }
+        }
+
+        fun updateList() {
+            createItemCells()
+            update(defaultViewList)
         }
     }
 }

--- a/app/src/main/java/com/nemo/androiduitraining/view/fragment/favorite/entity/FavoriteItemCell.kt
+++ b/app/src/main/java/com/nemo/androiduitraining/view/fragment/favorite/entity/FavoriteItemCell.kt
@@ -6,12 +6,12 @@ import com.nemo.androiduitraining.databinding.FavoriteNewItemItemCellBinding
 import com.xwray.groupie.viewbinding.BindableItem
 
 class FavoriteItemCell(
-    private val itemName: String,
-    private val brandName: String
+    private val brandName: String,
+    private val brandNameJapanese: String
 ) : BindableItem<FavoriteNewItemItemCellBinding>() {
     override fun bind(viewBinding: FavoriteNewItemItemCellBinding, position: Int) {
-        viewBinding.itemNameTv.text = itemName
-        viewBinding.brandTv.text = brandName
+        viewBinding.itemNameTv.text = brandName
+        viewBinding.brandTv.text = brandNameJapanese
     }
 
     override fun getLayout() = R.layout.favorite_new_item_item_cell

--- a/app/src/main/java/com/nemo/androiduitraining/view/fragment/favorite/entity/FavoriteItemCell.kt
+++ b/app/src/main/java/com/nemo/androiduitraining/view/fragment/favorite/entity/FavoriteItemCell.kt
@@ -5,9 +5,13 @@ import com.nemo.androiduitraining.R
 import com.nemo.androiduitraining.databinding.FavoriteNewItemItemCellBinding
 import com.xwray.groupie.viewbinding.BindableItem
 
-class FavoriteItemCell : BindableItem<FavoriteNewItemItemCellBinding>() {
+class FavoriteItemCell(
+    private val itemName: String,
+    private val brandName: String
+) : BindableItem<FavoriteNewItemItemCellBinding>() {
     override fun bind(viewBinding: FavoriteNewItemItemCellBinding, position: Int) {
-
+        viewBinding.itemNameTv.text = itemName
+        viewBinding.brandTv.text = brandName
     }
 
     override fun getLayout() = R.layout.favorite_new_item_item_cell

--- a/app/src/main/java/com/nemo/androiduitraining/view/fragment/favorite/entity/FavoriteItemCell.kt
+++ b/app/src/main/java/com/nemo/androiduitraining/view/fragment/favorite/entity/FavoriteItemCell.kt
@@ -1,17 +1,28 @@
 package com.nemo.androiduitraining.view.fragment.favorite.entity
 
+import android.content.res.Resources
 import android.view.View
+import android.view.ViewGroup
+import android.view.ViewGroup.LayoutParams.MATCH_PARENT
+import android.view.ViewGroup.LayoutParams.WRAP_CONTENT
 import com.nemo.androiduitraining.R
 import com.nemo.androiduitraining.databinding.FavoriteNewItemItemCellBinding
 import com.xwray.groupie.viewbinding.BindableItem
 
 class FavoriteItemCell(
     private val brandName: String,
-    private val brandNameJapanese: String
+    private val brandNameJapanese: String,
+    private val res: Resources
 ) : BindableItem<FavoriteNewItemItemCellBinding>() {
     override fun bind(viewBinding: FavoriteNewItemItemCellBinding, position: Int) {
         viewBinding.itemNameTv.text = brandName
         viewBinding.brandTv.text = brandNameJapanese
+
+        val layoutParams = ViewGroup.MarginLayoutParams(MATCH_PARENT, WRAP_CONTENT).apply {
+            this.marginStart = res.getDimension(R.dimen.side_margin_16).toInt()
+            this.marginEnd = res.getDimension(R.dimen.side_margin_16).toInt()
+        }
+        viewBinding.root.layoutParams = layoutParams
     }
 
     override fun getLayout() = R.layout.favorite_new_item_item_cell

--- a/app/src/main/java/com/nemo/androiduitraining/view/fragment/favorite/entity/FavoriteItemCell.kt
+++ b/app/src/main/java/com/nemo/androiduitraining/view/fragment/favorite/entity/FavoriteItemCell.kt
@@ -1,4 +1,18 @@
 package com.nemo.androiduitraining.view.fragment.favorite.entity
 
-class FavoriteItemCell : FavoriteItemModel() {
+import android.view.View
+import com.nemo.androiduitraining.R
+import com.nemo.androiduitraining.databinding.FavoriteNewItemItemCellBinding
+import com.xwray.groupie.viewbinding.BindableItem
+
+class FavoriteItemCell : BindableItem<FavoriteNewItemItemCellBinding>() {
+    override fun bind(viewBinding: FavoriteNewItemItemCellBinding, position: Int) {
+
+    }
+
+    override fun getLayout() = R.layout.favorite_new_item_item_cell
+
+    override fun initializeViewBinding(view: View): FavoriteNewItemItemCellBinding {
+        return FavoriteNewItemItemCellBinding.bind(view)
+    }
 }

--- a/app/src/main/java/com/nemo/androiduitraining/view/fragment/favorite/entity/FavoriteItemCell.kt
+++ b/app/src/main/java/com/nemo/androiduitraining/view/fragment/favorite/entity/FavoriteItemCell.kt
@@ -1,0 +1,4 @@
+package com.nemo.androiduitraining.view.fragment.favorite.entity
+
+class FavoriteItemCell : FavoriteItemModel() {
+}

--- a/app/src/main/java/com/nemo/androiduitraining/view/fragment/favorite/entity/FavoriteItemCell.kt
+++ b/app/src/main/java/com/nemo/androiduitraining/view/fragment/favorite/entity/FavoriteItemCell.kt
@@ -11,18 +11,11 @@ import com.xwray.groupie.viewbinding.BindableItem
 
 class FavoriteItemCell(
     private val brandName: String,
-    private val brandNameJapanese: String,
-    private val res: Resources
+    private val brandNameJapanese: String
 ) : BindableItem<FavoriteNewItemItemCellBinding>() {
     override fun bind(viewBinding: FavoriteNewItemItemCellBinding, position: Int) {
         viewBinding.itemNameTv.text = brandName
         viewBinding.brandTv.text = brandNameJapanese
-
-        val layoutParams = ViewGroup.MarginLayoutParams(MATCH_PARENT, WRAP_CONTENT).apply {
-            this.marginStart = res.getDimension(R.dimen.side_margin_16).toInt()
-            this.marginEnd = res.getDimension(R.dimen.side_margin_16).toInt()
-        }
-        viewBinding.root.layoutParams = layoutParams
     }
 
     override fun getLayout() = R.layout.favorite_new_item_item_cell

--- a/app/src/main/java/com/nemo/androiduitraining/view/fragment/favorite/entity/FavoriteItemModel.kt
+++ b/app/src/main/java/com/nemo/androiduitraining/view/fragment/favorite/entity/FavoriteItemModel.kt
@@ -1,0 +1,3 @@
+package com.nemo.androiduitraining.view.fragment.favorite.entity
+
+abstract class FavoriteItemModel

--- a/app/src/main/java/com/nemo/androiduitraining/view/fragment/favorite/entity/FavoriteItemModel.kt
+++ b/app/src/main/java/com/nemo/androiduitraining/view/fragment/favorite/entity/FavoriteItemModel.kt
@@ -1,3 +1,0 @@
-package com.nemo.androiduitraining.view.fragment.favorite.entity
-
-abstract class FavoriteItemModel

--- a/app/src/main/java/com/nemo/androiduitraining/view/fragment/favorite/entity/FavoriteNoBrandRegistered.kt
+++ b/app/src/main/java/com/nemo/androiduitraining/view/fragment/favorite/entity/FavoriteNoBrandRegistered.kt
@@ -1,0 +1,4 @@
+package com.nemo.androiduitraining.view.fragment.favorite.entity
+
+class FavoriteNoBrandRegistered : FavoriteItemModel() {
+}

--- a/app/src/main/java/com/nemo/androiduitraining/view/fragment/favorite/entity/FavoriteNoBrandRegistered.kt
+++ b/app/src/main/java/com/nemo/androiduitraining/view/fragment/favorite/entity/FavoriteNoBrandRegistered.kt
@@ -1,4 +1,18 @@
 package com.nemo.androiduitraining.view.fragment.favorite.entity
 
-class FavoriteNoBrandRegistered : FavoriteItemModel() {
+import android.view.View
+import com.nemo.androiduitraining.R
+import com.nemo.androiduitraining.databinding.FavoriteNewItemNoBrandRegisteredBinding
+import com.xwray.groupie.viewbinding.BindableItem
+
+class FavoriteNoBrandRegistered : BindableItem<FavoriteNewItemNoBrandRegisteredBinding>(){
+    override fun bind(viewBinding: FavoriteNewItemNoBrandRegisteredBinding, position: Int) {
+
+    }
+
+    override fun getLayout() = R.layout.favorite_new_item_no_brand_registered
+
+    override fun initializeViewBinding(view: View): FavoriteNewItemNoBrandRegisteredBinding {
+        return FavoriteNewItemNoBrandRegisteredBinding.bind(view)
+    }
 }

--- a/app/src/main/java/com/nemo/androiduitraining/view/fragment/favorite/entity/FavoriteNowPopular.kt
+++ b/app/src/main/java/com/nemo/androiduitraining/view/fragment/favorite/entity/FavoriteNowPopular.kt
@@ -1,0 +1,4 @@
+package com.nemo.androiduitraining.view.fragment.favorite.entity
+
+class FavoriteNowPopular : FavoriteItemModel() {
+}

--- a/app/src/main/java/com/nemo/androiduitraining/view/fragment/favorite/entity/FavoriteNowPopular.kt
+++ b/app/src/main/java/com/nemo/androiduitraining/view/fragment/favorite/entity/FavoriteNowPopular.kt
@@ -1,4 +1,18 @@
 package com.nemo.androiduitraining.view.fragment.favorite.entity
 
-class FavoriteNowPopular : FavoriteItemModel() {
+import android.view.View
+import com.nemo.androiduitraining.R
+import com.nemo.androiduitraining.databinding.FavoriteNewItemNowPopularBinding
+import com.xwray.groupie.viewbinding.BindableItem
+
+class FavoriteNowPopular : BindableItem<FavoriteNewItemNowPopularBinding>() {
+    override fun bind(viewBinding: FavoriteNewItemNowPopularBinding, position: Int) {
+
+    }
+
+    override fun getLayout() = R.layout.favorite_new_item_now_popular
+
+    override fun initializeViewBinding(view: View): FavoriteNewItemNowPopularBinding {
+        return FavoriteNewItemNowPopularBinding.bind(view)
+    }
 }

--- a/app/src/main/java/com/nemo/androiduitraining/viewModel/favorite/FavoriteNewItemViewModel.kt
+++ b/app/src/main/java/com/nemo/androiduitraining/viewModel/favorite/FavoriteNewItemViewModel.kt
@@ -1,5 +1,7 @@
 package com.nemo.androiduitraining.viewModel.favorite
 
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.viewbinding.ViewBinding
 import com.nemo.androiduitraining.view.fragment.favorite.entity.FavoriteItemCell
@@ -11,5 +13,22 @@ import javax.inject.Inject
 
 @HiltViewModel
 class FavoriteNewItemViewModel @Inject constructor() : ViewModel() {
+    private val _brandsLD = MutableLiveData<List<BrandItem>>()
+    val brandLD: LiveData<List<BrandItem>>
+        get() = _brandsLD
 
+    fun fetchBrandItems() {
+        val brandsList = mutableListOf<BrandItem>()
+        for (i in 0..29) {
+            brandsList.add(
+                BrandItem("ほげほげ", "フガフガ")
+            )
+        }
+        _brandsLD.postValue(brandsList)
+    }
+
+    data class BrandItem(
+        val name: String,
+        val genre: String
+    )
 }

--- a/app/src/main/java/com/nemo/androiduitraining/viewModel/favorite/FavoriteNewItemViewModel.kt
+++ b/app/src/main/java/com/nemo/androiduitraining/viewModel/favorite/FavoriteNewItemViewModel.kt
@@ -11,18 +11,5 @@ import javax.inject.Inject
 
 @HiltViewModel
 class FavoriteNewItemViewModel @Inject constructor() : ViewModel() {
-    private val _defaultViewList = mutableListOf(
-        FavoriteNoBrandRegistered(),
-        FavoriteNowPopular()
-    )
-    val defaultViewList: List<BindableItem<out ViewBinding>>
-        get() = _defaultViewList
 
-    fun createItemCells() {
-        for (i in 0..29) {
-            _defaultViewList.add(FavoriteItemCell(
-                "ほげほげ", "ふがふが"
-            ))
-        }
-    }
 }

--- a/app/src/main/java/com/nemo/androiduitraining/viewModel/favorite/FavoriteNewItemViewModel.kt
+++ b/app/src/main/java/com/nemo/androiduitraining/viewModel/favorite/FavoriteNewItemViewModel.kt
@@ -1,0 +1,10 @@
+package com.nemo.androiduitraining.viewModel.favorite
+
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class FavoriteNewItemViewModel @Inject constructor() : ViewModel() {
+
+}

--- a/app/src/main/java/com/nemo/androiduitraining/viewModel/favorite/FavoriteNewItemViewModel.kt
+++ b/app/src/main/java/com/nemo/androiduitraining/viewModel/favorite/FavoriteNewItemViewModel.kt
@@ -1,10 +1,28 @@
 package com.nemo.androiduitraining.viewModel.favorite
 
 import androidx.lifecycle.ViewModel
+import androidx.viewbinding.ViewBinding
+import com.nemo.androiduitraining.view.fragment.favorite.entity.FavoriteItemCell
+import com.nemo.androiduitraining.view.fragment.favorite.entity.FavoriteNoBrandRegistered
+import com.nemo.androiduitraining.view.fragment.favorite.entity.FavoriteNowPopular
+import com.xwray.groupie.viewbinding.BindableItem
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 
 @HiltViewModel
 class FavoriteNewItemViewModel @Inject constructor() : ViewModel() {
+    private val _defaultViewList = mutableListOf(
+        FavoriteNoBrandRegistered(),
+        FavoriteNowPopular()
+    )
+    val defaultViewList: List<BindableItem<out ViewBinding>>
+        get() = _defaultViewList
 
+    fun createItemCells() {
+        for (i in 0..29) {
+            _defaultViewList.add(FavoriteItemCell(
+                "ほげほげ", "ふがふが"
+            ))
+        }
+    }
 }

--- a/app/src/main/java/com/nemo/androiduitraining/viewModel/favorite/FavoriteNewItemViewModel.kt
+++ b/app/src/main/java/com/nemo/androiduitraining/viewModel/favorite/FavoriteNewItemViewModel.kt
@@ -29,6 +29,6 @@ class FavoriteNewItemViewModel @Inject constructor() : ViewModel() {
 
     data class BrandItem(
         val name: String,
-        val genre: String
+        val nameJapanese: String
     )
 }

--- a/app/src/main/res/drawable/fragment_favorite_new_item_divider.xml
+++ b/app/src/main/res/drawable/fragment_favorite_new_item_divider.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <size android:height="2dp" />
+    <solid android:color="@color/light_gray" />
+</shape>

--- a/app/src/main/res/drawable/ic_baseline_favorite_24.xml
+++ b/app/src/main/res/drawable/ic_baseline_favorite_24.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M12,21.35l-1.45,-1.32C5.4,15.36 2,12.28 2,8.5 2,5.42 4.42,3 7.5,3c1.74,0 3.41,0.81 4.5,2.09C13.09,3.81 14.76,3 16.5,3 19.58,3 22,5.42 22,8.5c0,3.78 -3.4,6.86 -8.55,11.54L12,21.35z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_baseline_keyboard_arrow_right_24.xml
+++ b/app/src/main/res/drawable/ic_baseline_keyboard_arrow_right_24.xml
@@ -1,0 +1,11 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal"
+    android:autoMirrored="true">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M8.59,16.59L13.17,12 8.59,7.41 10,6l6,6 -6,6 -1.41,-1.41z"/>
+</vector>

--- a/app/src/main/res/layout/favorite_new_item_item_cell.xml
+++ b/app/src/main/res/layout/favorite_new_item_item_cell.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/favorite_new_item_item_cell.xml
+++ b/app/src/main/res/layout/favorite_new_item_item_cell.xml
@@ -1,6 +1,79 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="wrap_content"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
 
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintDimensionRatio="h,5:1">
+
+        <androidx.constraintlayout.widget.Guideline
+            android:id="@+id/guideline_vertical1"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            app:layout_constraintGuide_percent="0.15"
+            android:orientation="vertical"/>
+
+        <androidx.constraintlayout.widget.Guideline
+            android:id="@+id/guideline_vertical2"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            app:layout_constraintGuide_percent="0.9"
+            android:orientation="vertical"/>
+
+        <ImageView
+            android:id="@+id/favorite_image"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="@id/guideline_vertical1"
+            android:src="@drawable/ic_baseline_favorite_24"
+            android:layout_margin="16dp"
+            app:tint="@color/text_gray"
+            app:layout_constraintHorizontal_chainStyle="packed"
+            app:layout_constraintHorizontal_bias="1"
+            android:contentDescription="@string/image"/>
+
+        <TextView
+            android:id="@+id/item_name_tv"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            app:layout_constraintStart_toStartOf="@id/guideline_vertical1"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintEnd_toEndOf="@id/guideline_vertical2"
+            app:layout_constraintBottom_toTopOf="@id/brand_tv"
+            android:textColor="@color/black"
+            app:layout_constraintHorizontal_bias="1"/>
+        <TextView
+            android:id="@+id/brand_tv"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            app:layout_constraintStart_toStartOf="@id/guideline_vertical1"
+            app:layout_constraintTop_toBottomOf="@id/item_name_tv"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="@id/guideline_vertical2"
+            android:textColor="@color/text_gray"
+            app:layout_constraintHorizontal_bias="1"/>
+
+        <ImageView
+            android:id="@+id/arrow_image"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            app:layout_constraintStart_toStartOf="@id/guideline_vertical2"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            android:src="@drawable/ic_baseline_keyboard_arrow_right_24"
+            app:tint="@color/text_gray"
+            app:layout_constraintHorizontal_weight="1"
+            android:contentDescription="@string/image"/>
+    </androidx.constraintlayout.widget.ConstraintLayout>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/favorite_new_item_item_cell.xml
+++ b/app/src/main/res/layout/favorite_new_item_item_cell.xml
@@ -76,7 +76,6 @@
             android:src="@drawable/ic_baseline_keyboard_arrow_right_24"
             app:tint="@color/text_gray"
             app:layout_constraintHorizontal_weight="1"
-            android:contentDescription="@string/image"
-            android:layout_marginEnd="16dp"/>
+            android:contentDescription="@string/image" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/favorite_new_item_item_cell.xml
+++ b/app/src/main/res/layout/favorite_new_item_item_cell.xml
@@ -2,6 +2,8 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:layout_marginStart="@dimen/side_margin_16"
+    android:layout_marginEnd="@dimen/side_margin_16"
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <androidx.constraintlayout.widget.ConstraintLayout

--- a/app/src/main/res/layout/favorite_new_item_item_cell.xml
+++ b/app/src/main/res/layout/favorite_new_item_item_cell.xml
@@ -17,7 +17,7 @@
             android:id="@+id/guideline_vertical1"
             android:layout_width="0dp"
             android:layout_height="0dp"
-            app:layout_constraintGuide_percent="0.15"
+            app:layout_constraintGuide_percent="0.1"
             android:orientation="vertical"/>
 
         <androidx.constraintlayout.widget.Guideline
@@ -36,7 +36,7 @@
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="@id/guideline_vertical1"
             android:src="@drawable/ic_baseline_favorite_24"
-            android:layout_margin="16dp"
+            android:layout_margin="8dp"
             app:tint="@color/text_gray"
             app:layout_constraintHorizontal_chainStyle="packed"
             app:layout_constraintHorizontal_bias="1"
@@ -76,6 +76,7 @@
             android:src="@drawable/ic_baseline_keyboard_arrow_right_24"
             app:tint="@color/text_gray"
             app:layout_constraintHorizontal_weight="1"
-            android:contentDescription="@string/image"/>
+            android:contentDescription="@string/image"
+            android:layout_marginEnd="16dp"/>
     </androidx.constraintlayout.widget.ConstraintLayout>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/favorite_new_item_item_cell.xml
+++ b/app/src/main/res/layout/favorite_new_item_item_cell.xml
@@ -50,6 +50,7 @@
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintEnd_toEndOf="@id/guideline_vertical2"
             app:layout_constraintBottom_toTopOf="@id/brand_tv"
+            android:gravity="start|bottom"
             android:textColor="@color/black"
             app:layout_constraintHorizontal_bias="1"/>
         <TextView
@@ -60,6 +61,7 @@
             app:layout_constraintTop_toBottomOf="@id/item_name_tv"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="@id/guideline_vertical2"
+            android:gravity="start|top"
             android:textColor="@color/text_gray"
             app:layout_constraintHorizontal_bias="1"/>
 

--- a/app/src/main/res/layout/favorite_new_item_no_brand_registered.xml
+++ b/app/src/main/res/layout/favorite_new_item_no_brand_registered.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/favorite_new_item_no_brand_registered.xml
+++ b/app/src/main/res/layout/favorite_new_item_no_brand_registered.xml
@@ -1,6 +1,57 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="wrap_content"
+    >
 
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintDimensionRatio="h,5:3"
+        android:background="@color/light_gray">
+
+        <ImageView
+            android:id="@+id/no_brand_image"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:src="@drawable/ic_android_black_24dp"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintBottom_toTopOf="@id/no_brand_tv_main"
+            android:contentDescription="@string/image"/>
+        <TextView
+            android:id="@+id/no_brand_tv_main"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            app:layout_constraintTop_toBottomOf="@id/no_brand_image"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintBottom_toTopOf="@id/no_brand_tv_sub"
+            android:text="@string/no_favorite_brand"
+            android:gravity="center"
+            android:textColor="@color/black"
+            android:textStyle="bold"
+            android:textSize="16sp"
+            android:layout_marginBottom="16dp"/>
+
+        <TextView
+            android:id="@+id/no_brand_tv_sub"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            app:layout_constraintTop_toBottomOf="@id/no_brand_tv_main"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            android:text="@string/no_brand_sub_text"
+            android:gravity="center"
+            android:textColor="@color/black"
+            android:layout_marginBottom="32dp"/>
+    </androidx.constraintlayout.widget.ConstraintLayout>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/favorite_new_item_now_popular.xml
+++ b/app/src/main/res/layout/favorite_new_item_now_popular.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/favorite_new_item_now_popular.xml
+++ b/app/src/main/res/layout/favorite_new_item_now_popular.xml
@@ -11,8 +11,7 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintDimensionRatio="h,7:2"
-        android:background="@color/light_gray">
+        app:layout_constraintDimensionRatio="h,7:2">
 
         <androidx.constraintlayout.widget.Guideline
             android:id="@+id/guideline_horizontal"

--- a/app/src/main/res/layout/favorite_new_item_now_popular.xml
+++ b/app/src/main/res/layout/favorite_new_item_now_popular.xml
@@ -1,6 +1,77 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="wrap_content"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
 
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintDimensionRatio="h,7:2"
+        android:background="@color/light_gray">
+
+        <androidx.constraintlayout.widget.Guideline
+            android:id="@+id/guideline_horizontal"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            app:layout_constraintGuide_percent="0.5"
+            android:orientation="horizontal"/>
+
+        <TextView
+            android:id="@+id/now_popular_tv"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            android:gravity="start|bottom"
+            app:layout_constraintBottom_toBottomOf="@id/guideline_horizontal"
+            android:text="@string/now_popular_brand"
+            android:textStyle="bold"
+            android:textColor="@color/black"
+            android:textSize="18sp"
+            android:layout_margin="16dp"/>
+
+        <ImageView
+            android:id="@+id/man_image"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            app:layout_constraintDimensionRatio="h,1:1"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toStartOf="@id/woman_image"
+            app:layout_constraintTop_toTopOf="@id/guideline_horizontal"
+            android:src="@drawable/ic_android_black_24dp"
+            app:tint="@color/person_image_blue"
+            android:contentDescription="@string/image"/>
+
+        <ImageView
+            android:id="@+id/woman_image"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            app:layout_constraintDimensionRatio="h,1:1"
+            app:layout_constraintStart_toEndOf="@id/man_image"
+            app:layout_constraintEnd_toStartOf="@id/child_image"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintTop_toTopOf="@id/guideline_horizontal"
+            android:src="@drawable/ic_android_black_24dp"
+            app:tint="@color/person_image_pink"
+            android:contentDescription="@string/image"/>
+
+        <ImageView
+            android:id="@+id/child_image"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            app:layout_constraintDimensionRatio="h,1:1"
+            app:layout_constraintStart_toEndOf="@id/woman_image"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="@id/guideline_horizontal"
+            android:src="@drawable/ic_android_black_24dp"
+            app:tint="@color/person_image_yellow"
+            android:contentDescription="@string/image"/>
+    </androidx.constraintlayout.widget.ConstraintLayout>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_favorite.xml
+++ b/app/src/main/res/layout/fragment_favorite.xml
@@ -6,7 +6,7 @@
 
     <com.google.android.material.appbar.AppBarLayout
         android:layout_width="match_parent"
-        android:layout_height="170dp"
+        android:layout_height="wrap_content"
         android:background="@color/dark_gray">
 
         <com.google.android.material.appbar.CollapsingToolbarLayout
@@ -58,7 +58,7 @@
         <com.google.android.material.tabs.TabLayout
             android:id="@+id/favorite_tab_layout"
             android:layout_width="match_parent"
-            android:layout_height="50dp"
+            android:layout_height="wrap_content"
             android:background="@color/dark_gray" />
     </com.google.android.material.appbar.AppBarLayout>
 

--- a/app/src/main/res/layout/fragment_favorite.xml
+++ b/app/src/main/res/layout/fragment_favorite.xml
@@ -70,7 +70,6 @@
         <androidx.viewpager2.widget.ViewPager2
             android:id="@+id/favorite_view_pager"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            app:layout_behavior="@string/appbar_scrolling_view_behavior" />
+            android:layout_height="match_parent" />
     </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/fragment_favorite.xml
+++ b/app/src/main/res/layout/fragment_favorite.xml
@@ -1,68 +1,68 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.coordinatorlayout.widget.CoordinatorLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
-    <androidx.constraintlayout.widget.ConstraintLayout
-        android:id="@+id/top_layout"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        android:layout_width="0dp"
+    <com.google.android.material.appbar.AppBarLayout
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:background="@color/dark_gray">
-
-        <ImageView
-            android:id="@+id/cart_img"
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/top_layout"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="16dp"
-            android:layout_marginEnd="16dp"
-            android:contentDescription="@string/cart"
-            android:src="@drawable/ic_android_black_24dp" />
-
-        <ImageView
-            android:id="@+id/bell_img"
-            app:layout_constraintEnd_toStartOf="@id/cart_img"
-            app:layout_constraintTop_toTopOf="parent"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="16dp"
-            android:layout_marginEnd="16dp"
-            android:contentDescription="@string/bell"
-            android:src="@drawable/ic_android_black_24dp" />
-
-        <TextView
-            app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/bell_img"
-            android:layout_width="wrap_content"
+            app:layout_constraintTop_toTopOf="parent"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginStart="16dp"
-            android:layout_marginBottom="16dp"
-            android:text="@string/favorite"
-            android:textColor="@color/black"
-            android:textStyle="bold" />
-    </androidx.constraintlayout.widget.ConstraintLayout>
+            app:layout_scrollFlags="scroll|enterAlwaysCollapsed">
 
-    <com.google.android.material.tabs.TabLayout
-        android:id="@+id/favorite_tab_layout"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/top_layout"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:background="@color/dark_gray" />
+            <ImageView
+                android:id="@+id/cart_img"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                android:layout_marginEnd="16dp"
+                android:contentDescription="@string/cart"
+                android:src="@drawable/ic_android_black_24dp" />
+
+            <ImageView
+                android:id="@+id/bell_img"
+                app:layout_constraintEnd_toStartOf="@id/cart_img"
+                app:layout_constraintTop_toTopOf="parent"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                android:layout_marginEnd="16dp"
+                android:contentDescription="@string/bell"
+                android:src="@drawable/ic_android_black_24dp" />
+
+            <TextView
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/bell_img"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:layout_marginBottom="16dp"
+                android:text="@string/favorite"
+                android:textColor="@color/black"
+                android:textStyle="bold" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+        <com.google.android.material.tabs.TabLayout
+            android:id="@+id/favorite_tab_layout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="@color/dark_gray"/>
+    </com.google.android.material.appbar.AppBarLayout>
 
     <androidx.viewpager2.widget.ViewPager2
         android:id="@+id/favorite_view_pager"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/favorite_tab_layout"
-        android:layout_width="0dp"
-        android:layout_height="0dp" />
-</androidx.constraintlayout.widget.ConstraintLayout>
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior" />
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/fragment_favorite.xml
+++ b/app/src/main/res/layout/fragment_favorite.xml
@@ -60,9 +60,15 @@
             android:background="@color/dark_gray"/>
     </com.google.android.material.appbar.AppBarLayout>
 
-    <androidx.viewpager2.widget.ViewPager2
-        android:id="@+id/favorite_view_pager"
+    <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        app:layout_behavior="@string/appbar_scrolling_view_behavior" />
+        app:layout_behavior="com.google.android.material.appbar.AppBarLayout$ScrollingViewBehavior">
+
+        <androidx.viewpager2.widget.ViewPager2
+            android:id="@+id/favorite_view_pager"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            app:layout_behavior="@string/appbar_scrolling_view_behavior" />
+    </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/fragment_favorite.xml
+++ b/app/src/main/res/layout/fragment_favorite.xml
@@ -1,63 +1,65 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.coordinatorlayout.widget.CoordinatorLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
+    android:layout_height="match_parent">
 
     <com.google.android.material.appbar.AppBarLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="170dp"
         android:background="@color/dark_gray">
-        <androidx.constraintlayout.widget.ConstraintLayout
-            android:id="@+id/top_layout"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
+
+        <com.google.android.material.appbar.CollapsingToolbarLayout
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            app:layout_scrollFlags="scroll|enterAlwaysCollapsed">
+            android:layout_height="120dp"
+            app:layout_scrollFlags="scroll|enterAlwaysCollapsed"
+            app:toolbarId="@+id/toolbar">
 
-            <ImageView
-                android:id="@+id/cart_img"
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:id="@+id/top_layout"
                 app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toTopOf="parent"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="16dp"
-                android:layout_marginEnd="16dp"
-                android:contentDescription="@string/cart"
-                android:src="@drawable/ic_android_black_24dp" />
-
-            <ImageView
-                android:id="@+id/bell_img"
-                app:layout_constraintEnd_toStartOf="@id/cart_img"
-                app:layout_constraintTop_toTopOf="parent"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="16dp"
-                android:layout_marginEnd="16dp"
-                android:contentDescription="@string/bell"
-                android:src="@drawable/ic_android_black_24dp" />
-
-            <TextView
-                app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/bell_img"
-                android:layout_width="wrap_content"
+                app:layout_constraintTop_toTopOf="parent"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginStart="16dp"
-                android:layout_marginBottom="16dp"
-                android:text="@string/favorite"
-                android:textColor="@color/black"
-                android:textStyle="bold" />
-        </androidx.constraintlayout.widget.ConstraintLayout>
+                app:layout_scrollFlags="scroll|enterAlwaysCollapsed">
+
+                <ImageView
+                    android:id="@+id/cart_img"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintTop_toTopOf="parent"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="16dp"
+                    android:layout_marginEnd="16dp"
+                    android:contentDescription="@string/cart"
+                    android:src="@drawable/ic_android_black_24dp" />
+
+                <ImageView
+                    android:id="@+id/bell_img"
+                    app:layout_constraintEnd_toStartOf="@id/cart_img"
+                    app:layout_constraintTop_toTopOf="parent"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="16dp"
+                    android:layout_marginEnd="16dp"
+                    android:contentDescription="@string/bell"
+                    android:src="@drawable/ic_android_black_24dp" />
+
+            </androidx.constraintlayout.widget.ConstraintLayout>
+
+            <androidx.appcompat.widget.Toolbar
+                android:id="@+id/toolbar"
+                android:layout_width="match_parent"
+                android:layout_height="?attr/actionBarSize"
+                app:title="@string/favorite" />
+        </com.google.android.material.appbar.CollapsingToolbarLayout>
 
         <com.google.android.material.tabs.TabLayout
             android:id="@+id/favorite_tab_layout"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:background="@color/dark_gray"/>
+            android:layout_height="50dp"
+            android:background="@color/dark_gray" />
     </com.google.android.material.appbar.AppBarLayout>
 
     <androidx.swiperefreshlayout.widget.SwipeRefreshLayout

--- a/app/src/main/res/layout/fragment_favorite_new_item.xml
+++ b/app/src/main/res/layout/fragment_favorite_new_item.xml
@@ -11,5 +11,6 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent" />
+        app:layout_constraintBottom_toBottomOf="parent"
+        android:overScrollMode="never"/>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_favorite_new_item.xml
+++ b/app/src/main/res/layout/fragment_favorite_new_item.xml
@@ -4,12 +4,13 @@
     android:layout_height="match_parent"
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
-    <TextView
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/favorite_new_item_recycler"
         android:layout_width="0dp"
         android:layout_height="0dp"
-        android:text="@string/favorite_new_item_fragment"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent"/>
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"/>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_favorite_new_item.xml
+++ b/app/src/main/res/layout/fragment_favorite_new_item.xml
@@ -11,6 +11,5 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"/>
+        app:layout_constraintBottom_toBottomOf="parent" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_favorite_new_item.xml
+++ b/app/src/main/res/layout/fragment_favorite_new_item.xml
@@ -1,16 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.recyclerview.widget.RecyclerView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/favorite_new_item_recycler"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
-
-    <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/favorite_new_item_recycler"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent"
-        android:overScrollMode="never"/>
-</androidx.constraintlayout.widget.ConstraintLayout>
+    android:overScrollMode="never"
+    app:layout_constraintBottom_toBottomOf="parent"
+    app:layout_constraintEnd_toEndOf="parent"
+    app:layout_constraintStart_toStartOf="parent"
+    app:layout_constraintTop_toTopOf="parent" />

--- a/app/src/main/res/values/dimen.xml
+++ b/app/src/main/res/values/dimen.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="side_margin_16">16dp</dimen>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -12,4 +12,7 @@
     <string name="favorite_item_fragment">FavoriteItemFragment</string>
     <string name="favorite_new_item_fragment">FavoriteNewItemFragment</string>
     <string name="favorite_brand_fragment">FavoriteBrandFragment</string>
+    <string name="no_favorite_brand">お気に入りのブランドの登録がありません</string>
+    <string name="no_brand_sub_text">気になるブランドをお気に入りに登録すると、\nブランドの新着アイテムがまとめてチェックできます。</string>
+    <string name="image">画像</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -15,4 +15,5 @@
     <string name="no_favorite_brand">お気に入りのブランドの登録がありません</string>
     <string name="no_brand_sub_text">気になるブランドをお気に入りに登録すると、\nブランドの新着アイテムがまとめてチェックできます。</string>
     <string name="image">画像</string>
+    <string name="now_popular_brand">今人気のブランド</string>
 </resources>


### PR DESCRIPTION
## 概要
・お気に入り画面の新着タブのrecyclerView実装
・CoordinatorLayout上側のレイアウトにのみ適用
## 関連情報

## スクリーンショット
 | Before | After |
 | -------- | ------ |
 | <image src="" width="320">|<image src="https://user-images.githubusercontent.com/77588574/136803042-276ffd2d-a03c-4497-a554-20335002d633.mp4"  width="320"> |
## 懸念点
お気に入りの文字の大きさが少し変わるところ
２段階？のCoordinatorLayoutとRefreshLayoutが合わさっているところどうすれば良いかわからない